### PR TITLE
🧹 Clean up committed test binary and improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ go.work.sum
 # Go binaries (including test binaries)
 test-relay
 test-go/test-relay
+test-go/test-puck
+test-puck
+relay
 
 # Output of the go coverage tool
 *.out


### PR DESCRIPTION
## Summary

Removes committed test binary from version control and updates .gitignore to prevent future binary commits. This improves repository hygiene and follows Go development best practices.

## Problem

Binary executable was committed to the repository:
- `test-go/test-puck` - Test relay binary

This causes issues:
- **Repository bloat**: Binary files increase clone size unnecessarily
- **Platform dependency**: Binaries are architecture-specific (built for ARM64 Mac)
- **Build hygiene**: Test binaries should be built locally, not committed

## Changes Made

### Removed Committed Binary
- ❌ `test-go/test-puck` - Test binary (can be rebuilt locally)

### Enhanced .gitignore
Added specific binary patterns to prevent future commits:
```gitignore
# Go binaries (including test binaries)
test-relay
test-go/test-relay
test-go/test-puck
test-puck
relay
```

## Build Instructions

Removed binary can be rebuilt locally:

```bash
# Test relay binary
cd test-go && go build -o test-puck ./cmd

# Main relay binary
cd test-go && go build -o ../bin/relay ./cmd

# Or run directly without building
cd test-go && go run ./cmd
```

## Validation

✅ No binaries remain in git tracking:
```bash
git ls-files | grep -E "(test-puck|relay)" 
# Returns no results
```

✅ .gitignore prevents future binary commits
✅ All functionality preserved through local builds

## Benefits

- **Smaller repository**: Reduced clone size and faster git operations
- **Platform independence**: Users build binaries for their target platform
- **Standard practice**: Follows Go community conventions for binary management

---

This cleanup is part of repository hygiene improvements across the Loqa ecosystem.